### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Ignore git
+.git
+.gitignore
+
+# Ignore Docker files
+Dockerfile
+.dockerignore
+
+# Ignore build
+node_modules
+public
+static/application.css

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM nginx:alpine
+
+RUN mkdir /build
+WORKDIR /build
+
+ENV HUGO_VERSION 0.37.1
+ENV HUGO_BINARY hugo_${HUGO_VERSION}_linux-64bit
+
+RUN apk upgrade --update-cache \
+  && apk add nodejs \
+             yarn
+
+RUN mkdir /usr/local/hugo
+ADD https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY}.tar.gz /usr/local/hugo/
+RUN tar xzf /usr/local/hugo/${HUGO_BINARY}.tar.gz -C /usr/local/hugo/ \
+	&& ln -s /usr/local/hugo/hugo /usr/local/bin/hugo \
+	&& rm /usr/local/hugo/${HUGO_BINARY}.tar.gz
+
+ADD package.json ./package.json
+RUN yarn install
+
+COPY . .
+
+RUN yarn run build \
+  && mv ./public/* /usr/share/nginx/html
+
+# Remove everything except the build
+RUN rm /usr/local/hugo/hugo \
+  && apk del nodejs yarn \
+  && rm -r *


### PR DESCRIPTION
For automated builds on Docker Hub.

This isn't very useful for local development because it doesn't watch for changes, but I think running hugo natively during development is much easier.

However, it can be run with
```
docker build -t starttls-frontend .
docker run --rm --name starttls-frontend-nginx -d -p 8080:80 starttls-frontend
```