### PR TITLE
WIP compose file for frontend and API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,6 @@ static/application.css
 # Ignore documentation and config
 Dockerfile
 .dockerignore
+docker-compose.yml
+nginx.conf
 README.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2.1'
+services:
+  nginx:
+    image: electronicfrontierfoundation/starttls-frontend
+    ports:
+      - '80:80'
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    links:
+      - scanner
+    # Development
+    # build: .
+
+  scanner:
+    image: electronicfrontierfoundation/starttls-scanner
+    depends_on:
+      - db
+    links:
+      - db
+    environment:
+      DB_HOST: db
+
+  db:
+    image: electronicfrontierfoundation/starttls-db
+    environment:
+      POSTGRES_DB: starttls

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+upstream scanner {
+  server scanner:8080;
+}
+
+server {
+  listen 80;
+  server_name localhost;
+
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+  }
+
+  location /api {
+    proxy_pass http://scanner/;
+    rewrite (.*) $1 break;
+  }
+}


### PR DESCRIPTION
Here's a first pass on a compose file for the API and frontend.

I'm not totally sure where this should live. I think this repo is a better candidate that `EFForg/scanner` because the scanner can stand alone, while the frontend needs the scanner to function.

This compose file isn't very useful for development because the frontend Dockerfile removes everything required to rebuild the site. In my experience developing natively and using Docker for testing can be better than trying to create a Docker setup that works for both development and production.

But this file won't match production either, since we use traefik there and will want a better password. @wgreenberg is there someplace techops stores compose files for production? Maybe this belongs there.