### PR TITLE
Correctly display mixed results

### DIFF
--- a/sass/components/checks.scss
+++ b/sass/components/checks.scss
@@ -22,12 +22,22 @@
 }
 
 
-.fail {
+.check.fail {
   .fail-title {
     display: block;
   }
 
   .default-title {
+    display: none;
+  }
+}
+
+.check.success {
+  .default-title {
+    display: block;
+  }
+
+  .fail-title {
     display: none;
   }
 }


### PR DESCRIPTION
Can be tested by running a scan on `selfsigned.starttls.party` - there should be a mix of checks and x's in the results.