### PR TITLE
fix(content): be a little more conservative in result wording

### DIFF
--- a/data/policy_check.yml
+++ b/data/policy_check.yml
@@ -7,4 +7,4 @@ list:
         Your mail domain is queued to be added to the <a href="/policy-list">STARTTLS policy list</a>. We’ll contact you by e-mail when this occurs, or you can check back here.
   - key: not-submitted
     body: |
-        Even if your mailservers support STARTTLS, someone sitting between your server and other mailservers can choose to drop “STARTTLS” messages and fool servers into thinking that you do not support TLS. To mitigate these downgrade attacks, add your domain to the <a href="/faq#what-list">STARTTLS Policy List</a>, so servers have another point of reference to discover that you support STARTTLS.
+        To help <a href="/faq#downgrades">mitigate downgrade attacks</a>, you can add your domain to the <a href="/faq#what-list">STARTTLS Policy List</a>, so servers have another point of reference to discover that you support STARTTLS.

--- a/layouts/partials/almost-there.html
+++ b/layouts/partials/almost-there.html
@@ -1,5 +1,0 @@
-<div class="pending not-submitted results-overview">
-  <h2>Almost there!</h2>
-
-  <p>Everything looks good, and a couple things can be even better.</p>
-</div>

--- a/layouts/partials/perfect.html
+++ b/layouts/partials/perfect.html
@@ -1,8 +1,6 @@
-<div class="perfect results-overview">
-  <h2>Perfect!</h2>
+<div class="perfect pending not-submitted results-overview">
+  <h2>Great!</h2>
 
-  <p>Your email domain supports STARTTLS, uses great TLS parameters, and presents a valid certificate!</p>
-
-  <p>As long as your recipient's mail service is also secure, your e-mail can only be read by *you*, *<span class="your-domain-name">your domain</span>*, your recipient, and your recipient's email service.</p>
+  <p>Your mailserver supports STARTTLS, uses great TLS parameters, and presents a valid certificate!</p>
 
 </div>

--- a/layouts/results/single.html
+++ b/layouts/results/single.html
@@ -18,7 +18,6 @@
   {{ partial "no-mxs" . }}
   {{ partial "fail-no-support" . }}
   {{ partial "fail-not-secured" . }}
-  {{ partial "almost-there" . }}
   {{ partial "perfect" . }}
 
   <h2 class="your-domain-name policy-check-header">Your Domain</h2>

--- a/sass/components/results.scss
+++ b/sass/components/results.scss
@@ -11,7 +11,7 @@
 
 .not-submitted.results-overview {
   @include results-title;
-  background-image: url("/images/gold-!-fill.svg");
+  background-image: url("/images/green-check-fill.svg");
   .what-is {
     @include susy-breakpoint($md) {
       margin: 1.5rem 26%;
@@ -26,7 +26,7 @@
 
 .pending.results-overview {
   @include results-title;
-  background-image: url("/images/gold-!-fill.svg");
+  background-image: url("/images/green-check-fill.svg");
 }
 
 .no-mxs,


### PR DESCRIPTION
Some wording/presentation nit-picking to be more accurate.
changes:
 - "Perfect!" => "Great!", because email security can never be guaranteed "Perfect"
 - turns `good.starttls.party` and `queued.starttls.party` into "green checks," rather than the "yellow !"-- since we don't want to imply list-addition is **guaranteed** extra security