### PR TITLE
Show error message on scan fail

### DIFF
--- a/js/results.js
+++ b/js/results.js
@@ -17,13 +17,13 @@ $(function() {
       domain: domain
     }
   })
+  .fail(handle_scan_error)
   .done(handle_scan)
-  .fail(handle_error);
 
   $('#manage').on('change', toggle_add_domain_actions);
 });
 
-function handle_error(data) {
+function handle_scan_error() {
   $('#loading-results').hide()
   $('#scan-request-failed').show()
 }

--- a/js/validate.js
+++ b/js/validate.js
@@ -17,13 +17,13 @@ $(function() {
       },
   })
   .done(handle_token)
-  .fail(handle_error);
+  .fail(handle_validate_error);
 });
 
 function handle_token(data) {
   $('#validation-success').show();
 }
 
-function handle_error(data) {
+function handle_validate_error(data) {
   $('#validation-failed').show();
 }


### PR DESCRIPTION
The ajax fail callback was not getting called because it was overwritten by another function with the same name.

Fixes #185 
Fixes #193 