### PR TITLE
Replace domain.org with example.com

### DIFF
--- a/layouts/add-domain/single.html
+++ b/layouts/add-domain/single.html
@@ -19,23 +19,23 @@
 
     <label for="email-input">Contact Email</label>
     <div id="email-description">
-      <p>We’ll use this e-mail to notify you of the status of your domain and potential deliverability issues. If left empty, we'll use the postmaster@domain.org address by default.</p>
+      <p>We’ll use this e-mail to notify you of the status of your domain and potential deliverability issues. If left empty, we'll use the postmaster@example.com address by default.</p>
     </div>
-    <input name="email" id="email-input" type="email" aria-describedby="email-description" placeholder="yourname@domain.org"></input>
+    <input name="email" id="email-input" type="email" aria-describedby="email-description" placeholder="yourname@example.com"></input>
 
     <fieldset>
       <legend>MX Hostnames</legend>
       <p>What hostnames are your TLS certificates valid for? Let us know, so a DNS man-in-the-middle can’t lie to others about your hostnames. 
       These hostnames can be fully qualified domain names, like `mx.example.com`, or domain suffixes, like .example.com.</p>
 
-      <input type="text" class="mx-domain" name="hostnames" placeholder="mx.domain.org" aria-label="Mx hostname 1" required>
+      <input type="text" class="mx-domain" name="hostnames" placeholder="mx.example.com" aria-label="Mx hostname 1" required>
       {{ range $i, $sequence := (seq 2 8) }}
-        <input type="text" class="mx-domain" name="hostnames" placeholder="mx.domain.org" aria-label="Mx hostname {{ $i }}">
+        <input type="text" class="mx-domain" name="hostnames" placeholder="mx.example.com" aria-label="Mx hostname {{ $i }}">
       {{ end }}
       <input type="button" class="add-another js-yes" value="+ Add another hostname">
     </fieldset>
 
-    <p>When you request submission, <strong>we'll send an email to postmaster@<span class="your-domain">yourdomain.org</span></strong> to validate your request, then queue <span class="your-domain">your domain</span> for submission for one week, and continually run security checks against <span class="your-domain">your domain</span>. If it continues to pass these checks, you’ll be added to the list! We will notify you of your domain status via the contact e-mail above, which, if specified, may be different from the postmaster address.</p>
+    <p>When you request submission, <strong>we'll send an email to postmaster@<span class="your-domain">{yourdomain}</span></strong> to validate your request, then queue <span class="your-domain">your domain</span> for submission for one week, and continually run security checks against <span class="your-domain">your domain</span>. If it continues to pass these checks, you’ll be added to the list! We will notify you of your domain status via the contact e-mail above, which, if specified, may be different from the postmaster address.</p>
 
     <p>When you are added to the list, you are required to continue meeting security guidelines. If for some reason you do not, this could impact deliverability. </p>
 


### PR DESCRIPTION
domain.org is owned by domain.com and may have valid email addresses. example.com should be used for cases like these.