### PR TITLE
Fix typo in page metadata

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,14 +21,14 @@
   <meta name="viewport" content="width=device-width" />
 
   <!-- Open graph !-->
-  <meta property="og:site_name" content="STARTTLS Everewhere"/>
+  <meta property="og:site_name" content="STARTTLS Everywhere"/>
   <meta property="og:image" content="https://starttls-everywhere.org/images/starttls-OG.png" />
-  <meta property="og:title" content="STARTTLS Everewhere"/>
+  <meta property="og:title" content="STARTTLS Everywhere"/>
   <meta property="og:description" content="Safer hops for email"/>
   <meta property="og:type" content="website"/>
   <!-- Twitter: card tags -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="STARTTLS Everewhere">
+  <meta name="twitter:title" content="STARTTLS Everywhere">
   <meta name="twitter:site" content="@EFF">
   <meta name="twitter:description" content="Safer hops for email">
   <meta name="twitter:image" content="https://starttls-everywhere.org/images/starttls-OG.png">


### PR DESCRIPTION
Fix typo in page metadata in order to show caption in IM previews properly