### PR TITLE
Add class for checks that should load as open

### DIFF
--- a/js/accordion.js
+++ b/js/accordion.js
@@ -1,6 +1,6 @@
 $(function() {
   //accordion
-  $('.accordion-title').removeClass('active');
+  $('.accordion-title:not(.js-default-open)').removeClass('active');
   $('body').on('click', '.accordion-title', function () {
     this.classList.toggle('active');
   });

--- a/layouts/results/single.html
+++ b/layouts/results/single.html
@@ -26,7 +26,7 @@
     {{ range $.Site.Data.policy_check.list }}
       <div class="check policy-list {{ .key }}">
 
-        <div class="accordion-title active">
+        <div class="accordion-title active js-default-open">
           <span>STARTTLS Policy List</span>
           <i></i>
         </div>


### PR DESCRIPTION
We added the active class to all accordions so they default to open for noscript users. Yay! Some of them should default to open for js users as well - adding a special class for that.