### PR TITLE
Show MTA-STS result in scan results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ public
 static/application.css
 static/application.js
 static/application.js.map
+static/templates.js
 node_modules
 static/vendor
 yarn-error.log

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,0 +1,26 @@
+Handlebars.registerHelper('ifCond', function (v1, operator, v2, options) {
+  switch (operator) {
+    case '==':
+      return (v1 == v2) ? options.fn(this) : options.inverse(this);
+    case '===':
+      return (v1 === v2) ? options.fn(this) : options.inverse(this);
+    case '!=':
+      return (v1 != v2) ? options.fn(this) : options.inverse(this);
+    case '!==':
+      return (v1 !== v2) ? options.fn(this) : options.inverse(this);
+    case '<':
+      return (v1 < v2) ? options.fn(this) : options.inverse(this);
+    case '<=':
+      return (v1 <= v2) ? options.fn(this) : options.inverse(this);
+    case '>':
+      return (v1 > v2) ? options.fn(this) : options.inverse(this);
+    case '>=':
+      return (v1 >= v2) ? options.fn(this) : options.inverse(this);
+    case '&&':
+      return (v1 && v2) ? options.fn(this) : options.inverse(this);
+    case '||':
+      return (v1 || v2) ? options.fn(this) : options.inverse(this);
+    default:
+      return options.inverse(this);
+  }
+});

--- a/js/results.js
+++ b/js/results.js
@@ -55,7 +55,11 @@ function handle_scan(data) {
 }
 
 function showMTASTSResult(result) {
-  result.status_class = result.status ? 'fail' : 'success';
+  var statuses = {
+    0: 'success',
+    1: 'almost',
+  }
+  result.status_class = statuses[result.status] || 'fail';
   result.all_messages = mtastsMessages(result);
   var html = Handlebars.templates['mta-sts-result'](result);
   $('#mta-sts-container').html(html);

--- a/js/results.js
+++ b/js/results.js
@@ -36,6 +36,7 @@ function handle_scan(data) {
     if (scan.results[hostname])
       showHostnameResult(hostname, scan.results[hostname])
   });
+  if (scan.mta_sts) showMTASTSResult(scan.mta_sts);
   // If there's only one hostname, the result for that hostname should be open by default.
   if ($('.hostname-result').length == 1) {
     $('.hostname-result .accordion-title').addClass('active')
@@ -51,6 +52,27 @@ function handle_scan(data) {
     behavior: 'smooth'
   });
 
+}
+
+function showMTASTSResult(result) {
+  result.status_class = result.status ? 'fail' : 'success';
+  result.all_messages = mtastsMessages(result);
+  var html = Handlebars.templates['mta-sts-result'](result);
+  $('#mta-sts-container').html(html);
+  $('.check.mta-sts').show();
+}
+
+function mtastsMessages(result) {
+  var msgs = result.messages || [];
+  $.each(result.checks, function(name, check) {
+    if (check.messages)
+      msgs = msgs.concat(check.messages);
+  });
+  // Strip leading "Warning:" or "Failure:"
+  msgs = msgs.map(function(msg) {
+    return msg.substring(msg.indexOf(":") + 1);
+  });
+  return msgs
 }
 
 function showHostnameResult(hostname, result) {

--- a/js/templates/mta-sts-result.handlebars
+++ b/js/templates/mta-sts-result.handlebars
@@ -15,20 +15,34 @@
         <p>We found the following{{#ifCond status '===' 0}} valid{{/ifCond}} policy on your mailserver:</p>
         <pre id="policy-text">{{policy}}</pre>
 
-        {{#ifCond all_messages.length '>' 0}}
-          <h5>Do you manage this email server?</h5>
-          <div class="messages">
-          {{#ifCond all_messages.length '===' 1}}
-            {{all_messages.[0]}}
-          {{else}}
-            <ul>
-            {{#each all_messages}}
-              <li>{{this}}</li>
-            {{/each}}
-            </ul>
+        <div class="messages">
+        <h5>Do you manage this email server?</h5>
+
+        {{#ifCond all_messages.length '===' 1}}
+          {{#ifCond status '===' 1}}
+            <p>Here's a suggestion for your deployment.</p>
           {{/ifCond}}
-          </div>
+          {{#ifCond status '>' 1}}
+            <p>We found a problem with your MTA-STS deployment.</p>
+          {{/ifCond}}
+          <p>{{all_messages.[0]}}</p>
         {{/ifCond}}
+
+        {{#ifCond all_messages.length '>' 1}}
+          {{#ifCond status '===' 1}}
+            <p>Here are some suggestions for your deployment:</p>
+          {{/ifCond}}
+          {{#ifCond status '>' 1}}
+            <p>We found these potential problems with your MTA-STS deployment:<p>
+          {{/ifCond}}
+          <ul>
+          {{#each all_messages}}
+            <li>{{this}}</li>
+          {{/each}}
+          </ul>
+        {{/ifCond}}
+        </div>
+
       {{else}}
         <p><strong>We couldn't find an MTA-STS record for your domain.<strong></p>
       {{/if}}

--- a/js/templates/mta-sts-result.handlebars
+++ b/js/templates/mta-sts-result.handlebars
@@ -13,9 +13,7 @@
 
       {{#if policy}}
         <p>We found the following{{#ifCond status '===' 0}} valid{{/ifCond}} policy on your mailserver:</p>
-        <div id="policy-text">
-          {{policy}}
-        </div>
+        <pre id="policy-text">{{policy}}</pre>
 
         {{#ifCond all_messages.length '>' 0}}
           <h5>Do you manage this email server?</h5>

--- a/js/templates/mta-sts-result.handlebars
+++ b/js/templates/mta-sts-result.handlebars
@@ -18,11 +18,15 @@
         {{#ifCond all_messages.length '>' 0}}
           <h5>Do you manage this email server?</h5>
           <div class="messages">
+          {{#ifCond all_messages.length '===' 1}}
+            {{all_messages.[0]}}
+          {{else}}
             <ul>
             {{#each all_messages}}
               <li>{{this}}</li>
             {{/each}}
             </ul>
+          {{/ifCond}}
           </div>
         {{/ifCond}}
       {{else}}

--- a/js/templates/mta-sts-result.handlebars
+++ b/js/templates/mta-sts-result.handlebars
@@ -1,0 +1,36 @@
+<article class="accordion">
+  <div class="check mta-sts {{status_class}}">
+
+    <div class="accordion-title active js-default-open">
+      <span>MTA-STS</span>
+      <i></i>
+    </div>
+    <div class="accordion-content">
+
+      <p>
+        MTA-STS is a standard that will make it more difficult to perform downgrade attacks on communications with your mailserver.
+      </p>
+
+      {{#if policy}}
+        <p>We found the following{{#ifCond status '===' 0}} valid{{/ifCond}} policy on your mailserver:</p>
+        <div id="policy-text">
+          {{policy}}
+        </div>
+
+        {{#ifCond all_messages.length '>' 0}}
+          <h5>Do you manage this email server?</h5>
+          <div class="messages">
+            <ul>
+            {{#each all_messages}}
+              <li>{{this}}</li>
+            {{/each}}
+            </ul>
+          </div>
+        {{/ifCond}}
+      {{else}}
+        <p><strong>We couldn't find an MTA-STS record for your domain.<strong></p>
+      {{/if}}
+
+    </div>
+  </div>
+</article>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,6 +15,8 @@
     data-sentry-id="{{ .Site.Params.SentryProjectID }}" >
   </script>
   <script src="../vendor/jquery.min.js"></script>
+  <script src="../vendor/handlebars.runtime.min.js"></script>
+  <script src="../templates.js"></script>
   <script src="../application.js"></script>
 
   <link rel="stylesheet" type="text/css" href="/application.css" />

--- a/layouts/results/single.html
+++ b/layouts/results/single.html
@@ -43,6 +43,8 @@
     {{ end }}
   </article>
 
+  <div id="mta-sts-container"></div>
+
   <h2>Mailboxes</h2>
   <article class="accordion domain-results">
     {{ partial "result-template" . }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "templates:build": "handlebars js/templates/* -f static/templates.js",
     "templates:watch": "yarn run templates:build && onchange 'js/templates/*' -- yarn run templates:build",
     "js:install": "mkdir -p static/vendor && cp node_modules/jquery/dist/jquery.min.js node_modules/raven-js/dist/raven.js node_modules/handlebars/dist/handlebars.runtime.min.js static/vendor",
-    "js:build": "yarn run js:install && yarn run js:templates && babel js --out-file static/application.js",
+    "js:build": "yarn run js:install && yarn run templates:build && babel js --out-file static/application.js",
     "js:watch": "yarn run js:install && parallelshell 'yarn run templates:watch' 'babel js --watch --out-file static/application.js --source-maps'",
     "build": "yarn run sass:build && yarn run js:build && hugo --config config.prod.toml,config.toml",
     "serve": "yarn run sass:build && parallelshell 'yarn run sass:watch' 'yarn run js:watch' 'hugo serve --config config.dev.toml,config.toml'",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "sass:build": "node-sass sass/application.scss static/application.css",
     "sass:watch": "onchange 'sass/**/*.scss*' -- yarn run sass:build",
-    "js:install": "mkdir -p static/vendor && cp node_modules/jquery/dist/jquery.min.js static/vendor/ && cp node_modules/raven-js/dist/raven.js static/vendor/",
-    "js:build": "yarn run js:install && babel js --out-file static/application.js",
-    "js:watch": "yarn run js:install && babel js --watch --out-file static/application.js --source-maps",
+    "templates:build": "handlebars js/templates/* -f static/templates.js",
+    "templates:watch": "yarn run templates:build && onchange 'js/templates/*' -- yarn run templates:build",
+    "js:install": "mkdir -p static/vendor && cp node_modules/jquery/dist/jquery.min.js node_modules/raven-js/dist/raven.js node_modules/handlebars/dist/handlebars.runtime.min.js static/vendor",
+    "js:build": "yarn run js:install && yarn run js:templates && babel js --out-file static/application.js",
+    "js:watch": "yarn run js:install && parallelshell 'yarn run templates:watch' 'babel js --watch --out-file static/application.js --source-maps'",
     "build": "yarn run sass:build && yarn run js:build && hugo --config config.prod.toml,config.toml",
     "serve": "yarn run sass:build && parallelshell 'yarn run sass:watch' 'yarn run js:watch' 'hugo serve --config config.dev.toml,config.toml'",
     "lint": "./node_modules/.bin/sass-lint -vq"
@@ -24,6 +26,7 @@
     "autoprefixer": "^7.1.2",
     "babel-cli": "^6.26.0",
     "babel-preset-babili": "^0.1.4",
+    "handlebars": "^4.0.12",
     "jquery": "^3.3.1",
     "node-sass": "^4.5.3",
     "onchange": "^3.2.1",

--- a/sass/components/results.scss
+++ b/sass/components/results.scss
@@ -81,9 +81,6 @@
 }
 
 .mta-sts {
-  h5 {
-    text-align: center;
-  }
 
   #policy-text {
     @extend p;
@@ -91,9 +88,14 @@
   }
 
   .messages {
-    padding: 12px;
+    margin-left: 4rem;
+    padding: 5px 15px;
     border: 2px solid $magenta;
     font-size: 1rem;
+
+    p {
+      padding-left: 0;
+    }
   }
 
   ul {

--- a/sass/components/results.scss
+++ b/sass/components/results.scss
@@ -80,6 +80,23 @@
   font-weight: bold;
 }
 
-#policy-text {
-  white-space: pre-line;
+.mta-sts {
+  h5 {
+    text-align: center;
+  }
+
+  #policy-text {
+    @extend p;
+    background-color: transparent;
+  }
+
+  .messages {
+    padding: 12px;
+    border: 2px solid $magenta;
+    font-size: 1rem;
+  }
+
+  ul {
+    margin: 0 0 0rem 1.5rem;
+  }
 }

--- a/sass/components/results.scss
+++ b/sass/components/results.scss
@@ -79,3 +79,7 @@
   color: $red;
   font-weight: bold;
 }
+
+#policy-text {
+  white-space: pre-line;
+}


### PR DESCRIPTION
Depends on #262 

The previous approach of templating most things out with Hugo at build time and then show/hiding them with jQuery based on the scan result was starting to work pretty badly, so I added a lightweight templating library. I think this could be used elsewhere if we make substantial changes to other parts of the results at some point!