### PR TITLE
Use lowercase key for anon-stats site id

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
     </div>
     {{ partial "site-index" . }}
   </div>
-  {{ if isset .Site.Params "AnonStatsID" }}
+  {{ if isset .Site.Params "anonstatsid" }}
     <noscript><img src="https://anon-stats.eff.org/js/?idsite={{ .Site.Params.AnonStatsID }} rec=1&action_name=" style="border:0" height="0" width="0" alt="" /></noscript>
     <div style="height: 0; width: 0; position: absolute" id="anon-stats"></div>
     <script type="text/javascript">


### PR DESCRIPTION
In Hugo, all site params are stored as lowercase so they can be accessed with any case when using the dot operator. Unfortunately this doesn't extend to the "isset" function, so the param must be lowercase there.

See https://discourse.gohugo.io/t/config-params-should-be-all-lowercase-or-not/5051