### PR TITLE
Remove local part of email from domain field

### DIFF
--- a/js/scan-form.js
+++ b/js/scan-form.js
@@ -3,10 +3,19 @@
  */
 $(function() {
   var $form = $("#scan");
+  var $domain = $form.find('input[name="domain"]');
+
+  $domain.blur(function() {
+    var domain = $domain.val();
+    if (domain.indexOf("@") >= 0) {
+      domain = domain.substring(domain.indexOf("@") + 1);
+      $domain.val(domain);
+    }
+  });
 
   $form.submit(function(e) {
     e.preventDefault();
-    var domain = $form.find('input[name="domain"]').val().trim();
+    var domain = $domain.val().trim();
     window.location = "/results?" + encodeURIComponent(domain);
   });
 });

--- a/layouts/partials/no-mxs.html
+++ b/layouts/partials/no-mxs.html
@@ -1,5 +1,5 @@
 <div class="results-overview no-mxs">
   <h2>Couldn't connect to <span class="your-domain-name">your domain</span></h2>
-  <p>We couldn't find any MX records for <span class="your-domain-name">your domain</span>! Did you make a typo or enter the wrong email domain? Make sure to enter the part of your email address after the @!</p>
+  <p>We couldn't find any MX records for <span class="your-domain-name">your domain</span>!</p>
   <p><a href="/">Try again?</a></p>
 </div>


### PR DESCRIPTION
Remove everything up to and including the `@` symbol in the domain input box when it loses focus.  This should let users enter email addresses and have them converted to domain names, addressing #249 