### PR TITLE
Differentiate network errors from failed validations

### DIFF
--- a/js/validate.js
+++ b/js/validate.js
@@ -25,5 +25,11 @@ function handle_token(data) {
 }
 
 function handle_validate_error(data) {
-  $('#validation-failed').show();
+  if (data.readyState === 0) {
+    $('#validation-network-error').show();
+  } else if (data.readyState === 4) {
+    $('#validation-failed').show();
+  } else {
+    $('#validation-unknown-error').show();
+  }
 }

--- a/layouts/validate/single.html
+++ b/layouts/validate/single.html
@@ -21,5 +21,17 @@
         Your token has either expired or already been used. To re-validate your email, <a href="/add-domain">try submitting your domain again!</a>
         </p>
     </div>
+    <div id="validation-network-error">
+        <h1 class="title">Network error</h1>
+        <p>
+        We could not connect to the server to confirm your request.  Please check your network connection and try again later.
+        </p>
+    </div>
+    <div id="validation-unknown-error">
+        <h1 class="title">Unknown error</h1>
+        <p>
+        An unexpected error occurred while attempting to connect to the server to confirm your request.  Please report this issue.
+        </p>
+    </div>
 </div>
 {{ end }}

--- a/sass/components/validate.scss
+++ b/sass/components/validate.scss
@@ -1,3 +1,3 @@
-#validation-success, #validation-failed {
+#validation-success, #validation-failed, #validation-network-error, #validation-unknown-error {
   display: none;
 }


### PR DESCRIPTION
Currently, if a network error is encountered while making a POST request to the API server's validation endpoint, the frontend will report that validation failed when in fact, it may simply be the network connection that failed.  This PR differentiates between the two cases and informs the user of what happened. Further information: https://stackoverflow.com/a/28404728